### PR TITLE
feat: Node Exporter can now track logged in users on machines

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -127,13 +127,13 @@
     prometheus = {
       exporters = {
         node = {
-	  enable = true;
-	  enabledCollectors = [ "systemd" ];
-	  port = 9002;
-	  extraFlags = [ "--collector.ethtool" "--collector.softirqs" "--collector.tcpstat" "--collector.wifi" ];
+          enable = true;
+          enabledCollectors = [ "systemd" ];
+          port = 9100;
+          extraFlags = [ "--collector.ethtool" "--collector.softirqs" "--collector.tcpstat" "--collector.wifi" ];
         };
       };
-    }
+    };
 };
 
   security.rtkit.enable = true;

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -133,6 +133,7 @@
         };
       };
     };
+  };
 
   security.rtkit.enable = true;
   hardware.pulseaudio.enable = false;

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -123,7 +123,18 @@
 
     fwupd.enable = true;
     avahi.enable = true;
-  };
+
+    prometheus = {
+      exporters = {
+        node = {
+	  enable = true;
+	  enabledCollectors = [ "systemd" ];
+	  port = 9002;
+	  extraFlags = [ "--collector.ethtool" "--collector.softirqs" "--collector.tcpstat" "--collector.wifi" ];
+        };
+      };
+    }
+};
 
   security.rtkit.enable = true;
   hardware.pulseaudio.enable = false;

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -134,7 +134,7 @@
         };
       };
     };
-};
+  };
 
   security.rtkit.enable = true;
   hardware.pulseaudio.enable = false;

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -123,18 +123,16 @@
 
     fwupd.enable = true;
     avahi.enable = true;
-
     prometheus = {
       exporters = {
         node = {
           enable = true;
-          enabledCollectors = [ "systemd" ];
           port = 9100;
-          extraFlags = [ "--collector.ethtool" "--collector.softirqs" "--collector.tcpstat" "--collector.wifi" ];
+          enabledCollectors = [ "systemd" "textfile"];
+          extraFlags = [ "--collector.ethtool" "--collector.softirqs" "--collector.tcpstat" "--collector.wifi" "--collector.textfile.directory=/var/lib/node_exporter/textfile_collector"];
         };
       };
     };
-  };
 
   security.rtkit.enable = true;
   hardware.pulseaudio.enable = false;
@@ -148,9 +146,45 @@
       ServerName printhost.ocf.berkeley.edu
       Encryption Always
     '';
+    "prometheus_scripts/logged_in_users_exporter.sh" = {
+      mode = "0555";
+      text = ''
+        #!/bin/bash
+        OUTPUT_FILE="/var/lib/node_exporter/textfile_collector/logged_in_users.prom"
+        who | awk '{print $1}' | sort | uniq | awk '{print "node_logged_in_user{name=\"" $1 "\"} 1"}' > "$OUTPUT_FILE"
+      '';
+    };
   };
 
   environment.etc."nixos/configuration.nix".text = ''
     {}: builtins.abort "This machine is not managed by /etc/nixos. Please use colmena instead."
   '';
+
+  # Create the textfile collector directory
+  systemd.tmpfiles.rules = [
+    "d /var/lib/node_exporter/textfile_collector 0755 root root -"
+    "d /etc/prometheus_scripts 0755 root root -"  
+    "z /etc/prometheus_scripts/logged_in_users_exporter.sh 0755 root root -"  
+  ];
+
+ 
+  systemd.timers."logged_in_users_exporter" = {
+    description = "Run logged_in_users_exporter.sh every 5 seconds";
+    wantedBy = [ "multi-user.target" ];
+      timerConfig = {
+        OnBootSec = "5s";
+        OnUnitActiveSec = "5s";
+        Unit = "logged_in_users_exporter.service";
+      };
+  };
+
+  systemd.services."logged_in_users_exporter" = {
+    description = "Logged in users exporter";
+    script = "bash /etc/prometheus_scripts/logged_in_users_exporter.sh";
+    serviceConfig = {
+      Environment = "PATH=/run/current-system/sw/bin";
+      Type = "oneshot";
+    };
+    wantedBy = [ "multi-user.target" ];
+  };
 }


### PR DESCRIPTION
With this PR, Node Exporter will now have the functionality to track which users are logged into a desktop machine.
This data can be accessible through Prometheus and Grafana with the 'node_logged_in_user' metric.
Supporting this addition is a few more additions to the 'systemd' configuration, introducing a new service and a timer for said service.