### PR TITLE
feat: updated logged_in_users_exporter.sh to use loginctl

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -152,7 +152,18 @@
       text = ''
         #!/bin/bash
         OUTPUT_FILE="/var/lib/node_exporter/textfile_collector/logged_in_users.prom"
-        who | awk '{print $1}' | sort | uniq | awk '{print "node_logged_in_user{name=\"" $1 "\"} 1"}' > "$OUTPUT_FILE"
+        > "$OUTPUT_FILE"
+        loginctl list-sessions --no-legend | while read -r session_id uid user seat leader class tty idle since; do
+          if [[ $class == "user" ]]; then
+            state=$(loginctl show-session "$session_id" -p State --value)
+            if [[ $state == "active" ]]; then
+              locked_status="unlocked"
+            else
+              locked_status="locked"
+            fi
+         echo "node_logged_in_user{name=\"$user\", state=\"$locked_status\"} 1" > $OUTPUT_FILE
+         fi
+       done
       '';
     };
   };


### PR DESCRIPTION
This is to better distinguish between active users and locked users who are still technically logged in but timed out or locked their user without logging out.