### PR TITLE
fix: node exporter no longer tracks ssh'd users

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -150,20 +150,20 @@
     "prometheus_scripts/logged_in_users_exporter.sh" = {
       mode = "0555";
       text = ''
-        #!/bin/bash
-        OUTPUT_FILE="/var/lib/node_exporter/textfile_collector/logged_in_users.prom"
-        > "$OUTPUT_FILE"
-        loginctl list-sessions --no-legend | while read -r session_id uid user seat leader class tty idle since; do
-          if [[ $class == "user" ]]; then
-            state=$(loginctl show-session "$session_id" -p State --value)
-            if [[ $state == "active" ]]; then
-              locked_status="unlocked"
-            else
-              locked_status="locked"
-            fi
-         echo "node_logged_in_user{name=\"$user\", state=\"$locked_status\"} 1" > $OUTPUT_FILE
-         fi
-       done
+	#!/bin/bash
+	OUTPUT_FILE="/var/lib/node_exporter/textfile_collector/logged_in_users.prom"
+	> "$OUTPUT_FILE"
+	loginctl list-sessions --no-legend | while read -r session_id uid user seat leader class tty idle since; do
+	   if [[ $class == "user" ]] && [[ $seat == "seat0" ]] && [[ $idle == "no" ]]; then
+	      state=$(loginctl show-session "$session_id" -p State --value)
+	      if [[ $state == "active" ]]; then
+		 locked_status="unlocked"
+	      else
+		 locked_status="locked"
+	      fi
+	   echo "node_logged_in_user{name=\"$user\", state=\"$locked_status\"} 1" > $OUTPUT_FILE
+	   fi
+	done
       '';
     };
   };


### PR DESCRIPTION
Fixing my previous commit, the list of users pushed to logged_in_users.prom now has a few more filters to account for various cases of logged in users. Now, only users who are seat0 and not idle will be accounted for. The only issue which continues to persist is the case of ocfstaff/ocfroot being timeout/lockout.