### PR TITLE
add simple-scan package to desktops

### DIFF
--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -65,6 +65,7 @@ in
     s-tui
     ocf-tv
     remmina
+    simple-scan
 
     # Cosmetics
     neofetch


### PR DESCRIPTION
desktop icon for scanners references a command for a package that isn't installed lol