### PR TITLE
fcitx5 pkgs to desktops for multilingual support

### DIFF
--- a/modules/ocf/graphical/default.nix
+++ b/modules/ocf/graphical/default.nix
@@ -60,11 +60,11 @@ in
       fcitx5.addons = with pkgs; [
         fcitx5-gtk
         fcitx5-mozc
-	fcitx5-rime
-	fcitx5-hangul
-	fcitx5-unikey
-	fcitx5-bamboo
-	fcitx5-m17n
+        fcitx5-rime
+        fcitx5-hangul
+        fcitx5-unikey
+        fcitx5-bamboo
+        fcitx5-m17n
       ];
     };
 


### PR DESCRIPTION
could definitely use some work/refining. need to document how to set defaults on home manager, but this at least gives people some GUI options on KDE Plasma.