### PR TITLE
Add papers back to desktops

### DIFF
--- a/modules/ocf/graphical/default.nix
+++ b/modules/ocf/graphical/default.nix
@@ -99,8 +99,11 @@ in
       blender
       xournalpp
       fastfetch
+      
+      # temporary substitute for okular landscape printing issue
+      papers
 
-      kdePackages.okular
+      ocf-okular
 
       # TEXT & CODE EDITORS
       vscode-fhs


### PR DESCRIPTION
We have been having issue with Okular where landscape pages would be printed in portrait mode instead. 
Papers does not have the same issue, and can thus be used as a temporary alternative for landscape printing.