### PR TITLE
fix sway on nvidia machines

### DIFF
--- a/modules/ocf/graphical/default.nix
+++ b/modules/ocf/graphical/default.nix
@@ -52,6 +52,7 @@ in
     programs.steam.enable = true;
     programs.zoom-us.enable = true;
     programs.sway.enable = true;
+    programs.sway.extraOptions = [ "--unsupported-gpu" ];
 
     i18n.inputMethod = {
       enable = true;


### PR DESCRIPTION
sway doesn't like nvidia drivers (justified, tbh) and will not launch with them active unless you specify a flag. so i added the flag x3