### PR TITLE
add nightly deploy

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - "main"
+  schedule:
+    - cron: "0 8 * * *"
 
 jobs:
-
   define-matrix:
     runs-on: ci-ocf-nix-deploy
     outputs:


### PR DESCRIPTION
We cannot ensure that deploys are successful at the time of a commit, and machines may remain outdated until the next successful commit. Nightly deploys act as a retry mechanism.