### PR TITLE
disable cri-o short name mode

### DIFF
--- a/modules/ocf/kubernetes/default.nix
+++ b/modules/ocf/kubernetes/default.nix
@@ -131,7 +131,10 @@ in
       };
     };
 
-    virtualisation.cri-o.enable = true;
+    virtualisation.cri-o = {
+      enable = true;
+      settings.crio.image.short_name_mode = "disabled";
+    };
 
     # NixOS cri-o config does weird stuff... reverting these
     environment.etc."cni/net.d/10-crio-bridge.conflist".enable = false;


### PR DESCRIPTION
temporary(?) fix for cri-o 1.34 enforcing short name mode: https://medium.com/@Shashank-tech/what-is-cri-o-1-34-why-its-important-now-afb89580679f

should probably do a proper update at some point

has been tested and deployed to the k8s nodes already