### PR TITLE
enable pcscd for accessing totp codes on yubikey

### DIFF
--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -162,6 +162,9 @@ in
   security.rtkit.enable = true;
   services.pulseaudio.enable = false;
 
+  # needed for accessing totp codes on yubikey via yubico authenticator
+  services.pcscd.enable = true;
+
   # Needed for generic Linux programs
   # More info: https://nix.dev/guides/faq#how-to-run-non-nix-executables
   programs.nix-ld.enable = true;


### PR DESCRIPTION
Enable pcscd, which is needed by yubioath-flutter (Yubico Authenticator) to access TOTP codes on a YubiKey.