### PR TITLE
disable automated deployment for tornado/overheat

### DIFF
--- a/hosts/misc/overheat.nix
+++ b/hosts/misc/overheat.nix
@@ -16,6 +16,9 @@
     # TODO: need ensure host keys can't be stolen by booting an external drive...
     acme.enable = false;
 
+    # this machine is not currently in use and cannot be deployed to
+    managed-deployment.automated-deploy = false;
+
     auth.enable = true;
 
     network = {

--- a/hosts/misc/tornado.nix
+++ b/hosts/misc/tornado.nix
@@ -11,6 +11,9 @@
     # TODO: need ensure host keys can't be stolen by booting an external drive...
     acme.enable = false;
 
+    # this machine is not currently in use and cannot be deployed to
+    managed-deployment.automated-deploy = false;
+
     auth.enable = true;
     browsers.enable = true;
 


### PR DESCRIPTION
these machines are not currently in use and cannot be deployed to. would rather just disable until we bring them back