### PR TITLE
disable nvidia for princess

### DIFF
--- a/hosts/desktops/princess.nix
+++ b/hosts/desktops/princess.nix
@@ -10,11 +10,6 @@
 
   networking.hostName = "princess";
 
-  ocf.nvidia = {
-    enable = true;
-    open = false;
-  };
-
   ocf.network = {
     enable = true;
     lastOctet = 162;


### PR DESCRIPTION
physically removed the 1060 that was in princess, updating nix configs to reflect this