### PR TITLE
matrix server: allow external accounts to look up rooms

### DIFF
--- a/modules/ocf/matrix/default.nix
+++ b/modules/ocf/matrix/default.nix
@@ -60,6 +60,9 @@ in
 
         auto_join_rooms = cfg.initialRooms;
 
+        # let people bridging from non-ocf accounts see all the discord rooms
+        allow_public_rooms_over_federation = true;
+
         alias_creation_rules = [
           {
             room_id = "#*:${cfg.serverName}";


### PR DESCRIPTION
So the matrix spaces thing I was talking on friday about isn't how the bridge works. If you wanted to you could make a matrix space and add all the rooms to it and then make an invite link to that space for external users but that's more trouble than it's worth. You'd have to add the chat to the space every time you added a channel to the discord.

Matrix spaces are matrix's analogue to discord servers, but I have no clue how well supported they are. They might just be an element thing.

So instead I propose you flip this switch. It should let external users from @matrix.org look up public rooms on ocf.io (the bridged rooms are public I checked).
https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html#allow_public_rooms_over_federation