### PR TITLE
feat: desktop scaling dependent on monitor

### DIFF
--- a/hosts/desktops/bolt.nix
+++ b/hosts/desktops/bolt.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:81:1c";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/callie.nix
+++ b/hosts/desktops/callie.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:7f:48";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/gozer.nix
+++ b/hosts/desktops/gozer.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:7f:6a";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/melange.nix
+++ b/hosts/desktops/melange.nix
@@ -20,10 +20,6 @@
 
   ocf.managed-deployment.mac-address = "d0:17:c2:d2:07:0c";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/pickles.nix
+++ b/hosts/desktops/pickles.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:81:1d";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/princess.nix
+++ b/hosts/desktops/princess.nix
@@ -17,10 +17,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:69:26:ac";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/socks.nix
+++ b/hosts/desktops/socks.nix
@@ -20,10 +20,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:7f:65";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/spud.nix
+++ b/hosts/desktops/spud.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:80:2a";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/sunny.nix
+++ b/hosts/desktops/sunny.nix
@@ -15,10 +15,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:30:e9:68";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/hosts/desktops/tabitha.nix
+++ b/hosts/desktops/tabitha.nix
@@ -20,10 +20,6 @@
 
   ocf.managed-deployment.mac-address = "9c:6b:00:38:7f:c8";
 
-  ocf.graphical = {
-    cosmic-scaling = "1.25";
-  };
-
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken. It‘s perfectly fine and recommended to leave

--- a/modules/ocf/graphical/default.nix
+++ b/modules/ocf/graphical/default.nix
@@ -17,12 +17,6 @@ in
       description = "Default desktop environment from display manager";
       default = "cosmic";
     };
-    # manually set in hostname config to 1.25 for 2k monitors (say dell on the bottom). 1.5 on 4k
-    cosmic-scaling = lib.mkOption {
-      type = lib.types.str;
-      description = "Default display scale on cosmic";
-      default = "1.5";
-    };
   };
 
 
@@ -154,7 +148,11 @@ in
           if [ -n "$mode" ]; then
             width=$(echo "$mode" | cut -d'x' -f1)
             height=$(echo "$mode" | cut -d'x' -f2 | cut -d' ' -f1)
-            ${pkgs.cosmic-randr}/bin/cosmic-randr mode "$output" "$width" "$height" --scale ${cfg.cosmic-scaling}
+            scale=1.25
+            if [[ "$height" -ge "2160" ]]; then
+                scale=1.5
+            fi
+            ${pkgs.cosmic-randr}/bin/cosmic-randr mode "$output" "$width" "$height" --scale "$scale"
           fi
         done
       '';


### PR DESCRIPTION
Reads the monitor resolution and scales desktop 1.25x for 2k monitors and 1.5x for 4k monitors. Deletes the `cosmic-scaling` property in the host configs.

⚠️I need to go test this in the lab but I don't see why it shouldn't work. Will update soon when tested⚠️