### PR TITLE
auto deploy: boot instead of switch

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -68,7 +68,7 @@ jobs:
               exit
             fi
 
-            if colmena apply --on {} switch > {}.log 2>&1; then
+            if colmena apply --on {} boot > {}.log 2>&1; then
               echo '✅ Successfully deployed to {}'
               echo 'SUCCESS:{}' >> results.txt
             else


### PR DESCRIPTION
switch causes problems sometimes, lets use boot by default instead. we can manually switch as needed until we implement an automatic method

todo:
- switch for servers?
- auto reboot for lab computers?