### PR TITLE
remove waiting for cups queue to clear

### DIFF
--- a/modules/printhost/cups.nix
+++ b/modules/printhost/cups.nix
@@ -153,7 +153,7 @@ in
 
         # ── Public Printers -------------─────────────────────────────────────
         lpadmin -p OCF-BW \
-          -v ipp://localhost/classes/OCF-BW-Group \
+          -v "ipp://localhost/classes/OCF-BW-Group?waitjob=false&waitprinter=false" \
           -P ${hpPpd} \
           -D "OCF Black & White" -L "OCF lab" \
           -E -o printer-is-shared=true -o Duplex=DuplexNoTumble


### PR DESCRIPTION
cups was waiting until the `OCF-BW-Group` queue cleared before sending it more prints, this makes no sense because the point of a load balancer is to load balance, and it was just going through the printers 1 by 1 in order, waiting for each print to finish first