### PR TITLE
add monitor brightness control

### DIFF
--- a/modules/graphical/default.nix
+++ b/modules/graphical/default.nix
@@ -186,9 +186,9 @@ in
                 RememberLastSession = false;
               };
 
-              # reset display brightness to 100% on logout/boot
-              setupScript = ''
-                ${pkgs.ddcutil}/bin/ddcutil setvcp 10 100";
+              # reset display brightness to 100% on logout
+              stopScript = ''
+                ${pkgs.ddcutil}/bin/ddcutil setvcp 10 100
               '';
             };
           };

--- a/modules/graphical/default.nix
+++ b/modules/graphical/default.nix
@@ -197,7 +197,7 @@ in
             Type = "oneshot";
             RemainAfterExit = true;
             ExecStart = "${pkgs.coreutils}/bin/true";
-            ExecStop = "${pkgs.ddcutil}/bin/ddcutil setvcp 10 100";
+            ExecStop = "${pkgs.ddcutil}/bin/ddcutil setvcp 10 85";
           };
         };
 

--- a/modules/graphical/default.nix
+++ b/modules/graphical/default.nix
@@ -185,6 +185,11 @@ in
                 RememberLastUser = false;
                 RememberLastSession = false;
               };
+
+              # reset display brightness to 100% on logout/boot
+              setupScript = ''
+                ${pkgs.ddcutil}/bin/ddcutil setvcp 10 100";
+              '';
             };
           };
         };

--- a/modules/graphical/default.nix
+++ b/modules/graphical/default.nix
@@ -185,12 +185,19 @@ in
                 RememberLastUser = false;
                 RememberLastSession = false;
               };
-
-              # reset display brightness to 100% on logout
-              stopScript = ''
-                ${pkgs.ddcutil}/bin/ddcutil setvcp 10 100
-              '';
             };
+          };
+        };
+
+        systemd.user.services.brightness-reset = {
+          description = "Reset monitor brightness to 100% on logout";
+          partOf = [ "graphical-session.target" ];
+          wantedBy = [ "graphical-session.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${pkgs.coreutils}/bin/true";
+            ExecStop = "${pkgs.ddcutil}/bin/ddcutil setvcp 10 100";
           };
         };
 

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -93,9 +93,9 @@ in
   ];
 
   # enable i2c and set udev rules for monitor brightness control
-  hardware.i2c.enable = true;
+  boot.kernelModules = [ "i2c-dev" ];
   services.udev.extraRules = ''
-    KERNEL=="i2c-[0-9]*", GROUP="ocf", MODE="0660"
+    KERNEL=="i2c-[0-9]*", TAG+="uaccess"
   '';
 
   services = {

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -88,7 +88,12 @@ in
 
     # IRC password prompt
     kdePackages.kdialog
+
+    ddcutil # for monitor brightness control
   ];
+
+  # enable i2c for monitor brightness control
+  hardware.i2c.enable = true;
 
   services = {
     avahi.enable = true;

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -95,7 +95,7 @@ in
   # enable i2c and set udev rules for monitor brightness control
   boot.kernelModules = [ "i2c-dev" ];
   services.udev.extraRules = ''
-    KERNEL=="i2c-[0-9]*", RUN+="${pkgs.coreutils}/bin/chgrp 1000 /dev/%k", RUN+="${pkgs.coreutils}/bin/chmod 0660 /dev/%k"
+    KERNEL=="i2c-[0-9]*", GROUP="ocf", MODE="0660"
   '';
 
   services = {

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -95,7 +95,7 @@ in
   # enable i2c and set udev rules for monitor brightness control
   boot.kernelModules = [ "i2c-dev" ];
   services.udev.extraRules = ''
-    KERNEL=="i2c-[0-9]*", TAG+="uaccess"
+    KERNEL=="i2c-[0-9]*", RUN+="${pkgs.coreutils}/bin/chgrp 1000 /dev/%k", RUN+="${pkgs.coreutils}/bin/chmod 0660 /dev/%k"
   '';
 
   services = {

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -95,7 +95,7 @@ in
   # enable i2c and set udev rules for monitor brightness control
   boot.kernelModules = [ "i2c-dev" ];
   services.udev.extraRules = ''
-    KERNEL=="i2c-[0-9]*", GROUP="ocf", MODE="0660"
+    KERNEL=="i2c-[0-9]*", RUN+="${pkgs.coreutils}/bin/chgrp 1000 /dev/%k", RUN+="${pkgs.coreutils}/bin/chmod 0660 /dev/%k"
   '';
 
   services = {

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -92,8 +92,11 @@ in
     ddcutil # for monitor brightness control
   ];
 
-  # enable i2c for monitor brightness control
+  # enable i2c and set udev rules for monitor brightness control
   hardware.i2c.enable = true;
+  services.udev.extraRules = ''
+    KERNEL=="i2c-[0-9]*", GROUP="ocf", MODE="0660"
+  '';
 
   services = {
     avahi.enable = true;


### PR DESCRIPTION
- fixes the i2c permissions so the cosmic brightness applet allows brightness control with a slider
- adds a script that resets the monitor brightness to 100% on logout