### PR TITLE
only apply QT_QPA_PLATFORMTHEME to cosmic desktop

### DIFF
--- a/modules/graphical/default.nix
+++ b/modules/graphical/default.nix
@@ -162,9 +162,12 @@ in
           noto-fonts-cjk-sans
         ];
 
-        environment.sessionVariables = {
-          QT_QPA_PLATFORMTHEME = "qt5ct";
-        };
+        # Only change the setting for cosmic
+        environment.extraInit = ''
+          if [ "$XDG_CURRENT_DESKTOP" = "COSMIC" ]; then
+            export QT_QPA_PLATFORMTHEME="qt5ct"
+          fi
+        '';
 
         programs.dconf.enable = true;
 


### PR DESCRIPTION
Fixes issues with this being set on KDE which prevents theming to work properly.