### PR TITLE
fix long file names failing to print

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -270,6 +270,7 @@
         catppuccin-sddm = final.qt6Packages.callPackage ./pkgs/catppuccin-sddm.nix { };
         ocf-cosmic-applets = ocf-cosmic-applets.packages.${final.stdenv.hostPlatform.system}.default;
         ocf-cosmic-greeter = final.callPackage ./pkgs/ocf-cosmic-greeter.nix { };
+        ocf-hplip = final.callPackage ./pkgs/ocf-hplip.nix { };
       };
 
       agenix-rekey = agenix-rekey.configure {

--- a/modules/printhost/cups.nix
+++ b/modules/printhost/cups.nix
@@ -50,7 +50,7 @@ let
   '';
 
   # Use official PPDs unmodified; defaults are set via lpadmin -o below.
-  hpPpd = "${pkgs.hplip}/share/cups/model/HP/hp-laserjet_m806-ps.ppd.gz";
+  hpPpd = "${pkgs.ocf-hplip}/share/cups/model/HP/hp-laserjet_m806-ps.ppd.gz";
   epsonPpd = "${pkgs.epson-escpr2}/share/cups/model/epson-inkjet-printer-escpr2/Epson-ET-5880_Series-epson-escpr2-en.ppd";
 
 in
@@ -83,7 +83,7 @@ in
       # hplip provides hpps (HP PPD filter); epson-escpr2 provides epson-escpr-wrapper2.
       drivers = [
         ocfCupsBackend
-        pkgs.hplip
+        pkgs.ocf-hplip
         pkgs.epson-escpr2
       ];
     };

--- a/pkgs/ocf-hplip.nix
+++ b/pkgs/ocf-hplip.nix
@@ -1,0 +1,10 @@
+{ hplip }:
+# This patches hplip's hppsfilter.c to replace all sprintf() calls
+# with snprintf() to prevent buffer overflows when CUPS passes long
+# job titles to the hpps filter via argv[3].
+
+hplip.overrideAttrs (oldAttrs: {
+  patches = (oldAttrs.patches or [ ]) ++ [
+    ./ocf-hplip/hpps-snprintf.patch
+  ];
+})

--- a/pkgs/ocf-hplip/hpps-snprintf.patch
+++ b/pkgs/ocf-hplip/hpps-snprintf.patch
@@ -1,0 +1,97 @@
+--- a/prnt/hpps/hppsfilter.c
++++ b/prnt/hpps/hppsfilter.c
+@@ -329,11 +329,11 @@ static void WriteHeader(char **argument)
+     /*      Writing Header Information
+     argument[1] = JOB ID , argument[2]= USERNAME,  argument[3] = TITLE      */
+     hpwrite("\x1b%-12345X@PJL JOBNAME=", strlen("\x1b%-12345X@PJL JOBNAME="));
+-    sprintf(buffer, "hplip_%s_%s\x0a", argument[2], argument[1]);
++    snprintf(buffer, sizeof(buffer), "hplip_%s_%s\x0a", argument[2], argument[1]);
+     hpwrite(buffer, strlen(buffer));
+     memset(buffer, 0, sizeof(buffer));
+-    sprintf(buffer, "@PJL SET USERNAME=\"%s\"\x0a", argument[2]);
++    snprintf(buffer, sizeof(buffer), "@PJL SET USERNAME=\"%s\"\x0a", argument[2]);
+     hpwrite(buffer, strlen(buffer));
+     memset(buffer, 0, sizeof(buffer));
+-    sprintf(buffer, "@PJL SET JOBNAME=\"%s\"\x0a", argument[3]);
++    snprintf(buffer, sizeof(buffer), "@PJL SET JOBNAME=\"%s\"\x0a", argument[3]);
+     hpwrite(buffer, strlen(buffer));
+     fprintf(stderr, "HP PS filter func = WriteHeader           : WRITING PJL HEADER INFO\n");
+     return;
+@@ -453,25 +453,25 @@ static unsigned char WriteJobAccounting(char **argument, int num_options, cups_op
+        const char *val             = NULL;
+        time_t t;
+        struct tm *tmp;
+ 
+ 
+-       sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct1=%s\"\x0a", argument[2]);
++       snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct1=%s\"\x0a", argument[2]);
+        hpwrite(buffer, strlen(buffer));
+        memset(buffer, 0, sizeof(buffer));
+        gethostname(name, sizeof(name));
+        if((strlen(name)) < 1)
+        { 
+-         sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct2=%s\"\x0a", "unknown_system_name");
++         snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct2=%s\"\x0a", "unknown_system_name");
+          hpwrite(buffer, strlen(buffer));
+          memset(buffer, 0, sizeof(buffer));
+        }
+        else
+        {
+-         sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct2=%s\"\x0a", name);
++         snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct2=%s\"\x0a", name);
+          hpwrite(buffer, strlen(buffer));
+          memset(buffer, 0, sizeof(buffer));
+        }
+        memset(name, 0, sizeof(name));
+        getdomainname(name,sizeof(name));
+        if(strstr(name, "none") != NULL)
+        { 
+-           sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct3=%s\"\x0a", "unknown_domain_name");
++           snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct3=%s\"\x0a", "unknown_domain_name");
+            hpwrite(buffer, strlen(buffer));
+            memset(buffer, 0, sizeof(buffer));
+        }
+        else
+        {
+-           sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct3=%s\"\x0a", name);
++           snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct3=%s\"\x0a", name);
+            hpwrite(buffer, strlen(buffer));
+            memset(buffer, 0, sizeof(buffer));
+        }
+@@ -496,7 +496,7 @@ static unsigned char WriteJobAccounting(char **argument, int num_options, cups_op
+              return 0;
+           }
+ 
+-           sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct4=%s\"\x0a", outstr);
++           snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct4=%s\"\x0a", outstr);
+            hpwrite(buffer, strlen(buffer));
+            memset(buffer, 0, sizeof(buffer));
+            if((val = cupsGetOption("job-uuid", num_options, options)) != NULL)
+@@ -505,7 +505,7 @@ static unsigned char WriteJobAccounting(char **argument, int num_options, cups_op
+                 if(input_slot)
+                 {
+-                 sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct5=%s\"\x0a", input_slot);
++                 snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct5=%s\"\x0a", input_slot);
+                  hpwrite(buffer, strlen(buffer));
+                  memset(buffer, 0, sizeof(buffer));
+                  
+@@ -515,11 +515,11 @@ static unsigned char WriteJobAccounting(char **argument, int num_options, cups_op
+             { 
+               fprintf(stderr, "HP PS filter func = WriteJobAccounting : JOB ACCOUNTING INFO FAILED -3\n");
+               return 0;
+             }
+-            sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct6=%s\"\x0a", "HP Linux Printing");
++            snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct6=%s\"\x0a", "HP Linux Printing");
+             hpwrite(buffer, strlen(buffer));
+             memset(buffer, 0, sizeof(buffer));
+ 
+-            sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct7=%s\"\x0a", "HP Linux Printing");
++            snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct7=%s\"\x0a", "HP Linux Printing");
+             hpwrite(buffer, strlen(buffer));
+             memset(buffer, 0, sizeof(buffer));
+ 
+-            sprintf(buffer, "@PJL SET JOBATTR=\"JobAcct8=%s\"\x0a", argument[2]);
++            snprintf(buffer, sizeof(buffer), "@PJL SET JOBATTR=\"JobAcct8=%s\"\x0a", argument[2]);
+             hpwrite(buffer, strlen(buffer));
+             memset(buffer, 0, sizeof(buffer));
+             fprintf(stderr, "HP PS filter func = WriteJobAccounting    : WRITING JOB ACCOUNTING INFO\n");


### PR DESCRIPTION
patch hplip to fix a buffer overflow caused by filenames around >=256 characters long

mostly tax documents, where the filename is already long and then the browser inserts a really long string of letters at the end for some reason

uses `snprintf` instead of `sprintf` to ensure the buffer length is respected