### PR TITLE
allow user customizable skeleton directories on desktops

### DIFF
--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -23,12 +23,12 @@ in
     };
   };
 
-  assertions = lib.mkIf cfg.mountRemote lib.singleton {
-    assertion = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
-    message = "ocf.home.mountRemote requires ocf.home.tmpfs and nfs mounted /remote and /services";
-  };
-
   config = lib.mkIf cfg.tmpfs {
+    assertions = lib.mkIf cfg.mountRemote lib.singleton {
+      assertion = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
+      message = "ocf.home.mountRemote requires ocf.home.tmpfs and nfs mounted /remote and /services";
+    };
+
     fileSystems."/home" = {
       device = "tmpfs";
       fsType = "tmpfs";

--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -67,7 +67,7 @@ in
             order = cfgPam.mount.order + 50;
             control = "optional";
             modulePath = "pam_exec.so";
-            args = [ if cfg.mountRemote then "${mountRemoteScript}" else "${tmpfsScript}" ];
+            args = [ (if cfg.mountRemote then "${mountRemoteScript}" else "${tmpfsScript}") ];
           };
         };
     };

--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -24,10 +24,12 @@ in
   };
 
   config = lib.mkIf cfg.tmpfs {
-    assertions = lib.mkIf cfg.mountRemote lib.singleton {
-      assertion = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
-      message = "ocf.home.mountRemote requires ocf.home.tmpfs and nfs mounted /remote and /services";
-    };
+    assertions = lib.mkIf cfg.mountRemote (
+      lib.singleton {
+        assertion = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
+        message = "ocf.home.mountRemote requires ocf.home.tmpfs and nfs mounted /remote and /services";
+      }
+    );
 
     fileSystems."/home" = {
       device = "tmpfs";

--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -7,7 +7,7 @@
 
 let
   cfg = config.ocf.home;
-  homeSetupScript = pkgs.writeShellScript "ocf_tmpfs_skel" (builtins.readFile ./ocf_tmpfs_skel.sh);
+  tmpfsScript = pkgs.writeShellScript "ocf_tmpfs_skel" (builtins.readFile ./ocf_tmpfs_skel.sh);
   mountRemoteScript = pkgs.writeShellScript "ocf_mount_remote" (
     builtins.readFile ./ocf_mount_remote.sh
   );
@@ -19,8 +19,13 @@ in
     mountRemote = lib.mkOption {
       type = lib.types.bool;
       default = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
-      description = "nfs mount ~/remote"; # TODO: fallback to sshfs if nfs is not enabled (currently no hosts do this)
+      description = "nfs mount ~/remote, copy skel from remote on login if it exists";
     };
+  };
+
+  assertions = lib.mkIf cfg.mountRemote lib.singleton {
+    assertion = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
+    message = "ocf.home.mountRemote requires ocf.home.tmpfs and nfs mounted /remote and /services";
   };
 
   config = lib.mkIf cfg.tmpfs {
@@ -41,38 +46,28 @@ in
         order = 0;
       };
 
+      # mount ~ as tmpfs
       services.login.pamMount = true;
-
-      # mount ~ and ~/remote
       mount.extraVolumes = [
         ''<volume fstype="tmpfs" path="tmpfs" mountpoint="~" options="uid=%(USERUID),gid=%(USERGID),mode=0700"/>''
-        # TODO: enable StrictHostKeyChecking and UserKnownHostsFile because these should not be disabled!
-        #''<volume fstype="fuse" path="${lib.getExe sshfs}#%(USER)@${remoteHost}:" mountpoint="~/remote/" options="follow_symlinks,UserKnownHostsFile=/dev/null,StrictHostKeyChecking=no" pgrp="ocf" />''
       ];
 
-      # because mount now creates the home dir and mounts tmpfs on it, mkhomedir wont copy the skel because the dir exists
-      # we can do copy skel as part of a home setup script, and do other stuff as well
-      #services.login.rules.session.mkhomedir.order = config.security.pam.services.login.rules.session.mount.order + 50;
-      #makeHomeDir.skelDirectory = "/etc/skel";
+      # because mount now creates the home dir and mounts tmpfs on it,
+      # mkhomedir wont copy the skel because the dir exists. we can copy skel
+      # as part of a home setup script, and do other stuff as well
 
       services.login.rules.session =
         let
           cfgPam = config.security.pam.services.login.rules.session;
         in
         {
-          # needed to mount ~/remote with kerberos ssh auth
+          # needed to mount ~/remote with kerberos auth
           mount.order = cfgPam.krb5.order + 50;
-          ocf_tmpfs_skel = {
+          ocf_home_setup = {
             order = cfgPam.mount.order + 50;
             control = "optional";
             modulePath = "pam_exec.so";
-            args = [ "${homeSetupScript}" ];
-          };
-          ocf_mount_remote = lib.mkIf cfg.mountRemote {
-            order = cfgPam.mount.order + 100;
-            control = "optional";
-            modulePath = "pam_exec.so";
-            args = [ "${mountRemoteScript}" ];
+            args = [ if cfg.mountRemote then "${mountRemoteScript}" else "${tmpfsScript}" ];
           };
         };
     };

--- a/modules/home/ocf_mount_remote.sh
+++ b/modules/home/ocf_mount_remote.sh
@@ -3,49 +3,65 @@
 user_home="$(getent passwd "$PAM_USER" | cut -d: -f6)"
 user_gid="$(getent passwd "$PAM_USER" | cut -d: -f4)"
 
-remote_source="/remote/${PAM_USER:0:1}/${PAM_USER:0:2}/$PAM_USER"
-remote_dest="$user_home/remote"
-remote_skel="$remote_source/.config/ocf/skel"
+# kerberos ticket is needed to access user's home directory
+KRB5CCNAME=/tmp/krb5cc_$(id -u "$PAM_USER")
+
+remote_source="/remote/${PAM_USER:0:1}/${PAM_USER:0:2}/$PAM_USER/"
+remote_dest="$user_home/remote/"
+
+# i wish i could check XDG_CONFIG_HOME, but we are so early in
+# loading that the user cannot set the environment variable.
+# also the config dir in question is on a remote host, which
+# makes this even more complicated.
+remote_skel="$remote_source/.config/ocf/skel/"
+# TODO: add ability to have multiple overlaying skeletons that are copied in
+# alphabetical order (skel.d)
 
 umask 0077
 
+# populate users' mounted tmpfs home with skel
 copy_skel() {
-	skel="$1"
-	# populate users tmpfs home with skel
 	# check to make sure that the directory is actually empty
 	# FIXME: expects findutils to exist
-	if [ -d "$user_home" ] && [ -n "$(find "$user_home" -maxdepth 0 -empty)" ]; then
+	if [ ! -d "$user_home" ] || [ ! -n "$(find "$user_home" -maxdepth 0 -empty)" ]; then
+		return
+	fi
+
+	# if skel is set by user, copy that instead of default
+
+	if su "$PAM_USER" -c "test -d \"$remote_skel\""; then
+		echo "ocf-setup-home: copying $remote_skel to $user_home"
+		# preserving file mode/perms is intentional
+		su "$PAM_USER" -c "cp -rT \"$remote_skel\" \"$user_home\""
+	else
 		# /etc/skel is read only because its in the nix store.
 		# we should follow umask like how pam_mkhomedir does
-		echo "ocf-setup-home: copying $skel to $user_home/"
-		cp -rT --no-preserve=mode "$skel" "$user_home/"
-		chown -R "$PAM_USER:$user_gid" "$user_home/"
+		echo "ocf-setup-home: copying /etc/skel/ to $user_home"
+		cp -rT --no-preserve=mode /etc/skel/ "$user_home"
+		chown -R "$PAM_USER:$user_gid" "$user_home"
 	fi
+}
+
+mount_remote() {
+	# bind mount ~/remote to nfs
+	echo "ocf-mount-remote: bind mounting $remote_source to $remote_dest."
+	mkdir -p "$remote_dest"
+	mount -o bind "$remote_source" "$remote_dest"
+}
+
+umount_remote() {
+	# unmount everything under the users home dir
+	# FIXME: handle cases where user leaves the mountpoint busy
+	echo "ocf-mount-remote: unmounting $remote_dest."
+	umount "$remote_dest"
 }
 
 case "$PAM_TYPE" in
 	open_session)
-		# i wish i could check XDG_CONFIG_HOME, but we are so early in
-		# loading that the user cannot set the environment variable.
-		# also the config dir in question is on a remote host, which
-		# makes this even more complicated.
-
-		# if skel is set by user, copy that instead of default
-		if [ -d "$remote_skel" ]; then
-			copy_skel "$remote_skel"
-		else
-			copy_skel /etc/skel
-		fi
-
-		# bind mount ~/remote to nfs
-		echo "ocf-mount-remote: bind mounting $remote_source/ to $remote_dest."
-		mkdir -p "$remote_dest"
-		mount -o bind "$remote_source" "$remote_dest"
+		copy_skel
+		mount_remote
 		;;
 	close_session)
-		# unmount everything under the users home dir
-		# FIXME: handle cases where user leaves the mountpoint busy
-		echo "ocf-mount-remote: unmounting $remote_dest."
-		umount "$remote_dest"
+		umount_remote
 		;;
 esac

--- a/modules/home/ocf_mount_remote.sh
+++ b/modules/home/ocf_mount_remote.sh
@@ -5,11 +5,38 @@ user_gid="$(getent passwd "$PAM_USER" | cut -d: -f4)"
 
 remote_source="/remote/${PAM_USER:0:1}/${PAM_USER:0:2}/$PAM_USER"
 remote_dest="$user_home/remote"
+remote_skel="$remote_source/.config/ocf/skel"
 
 umask 0077
 
+copy_skel() {
+	skel="$1"
+	# populate users tmpfs home with skel
+	# check to make sure that the directory is actually empty
+	# FIXME: expects findutils to exist
+	if [ -d "$user_home" ] && [ -n "$(find "$user_home" -maxdepth 0 -empty)" ]; then
+		# /etc/skel is read only because its in the nix store.
+		# we should follow umask like how pam_mkhomedir does
+		echo "ocf-setup-home: copying $skel to $user_home/"
+		cp -rT --no-preserve=mode "$skel" "$user_home/"
+		chown -R "$PAM_USER:$user_gid" "$user_home/"
+	fi
+}
+
 case "$PAM_TYPE" in
 	open_session)
+		# i wish i could check XDG_CONFIG_HOME, but we are so early in
+		# loading that the user cannot set the environment variable.
+		# also the config dir in question is on a remote host, which
+		# makes this even more complicated.
+
+		# if skel is set by user, copy that instead of default
+		if [ -d "$remote_skel" ]; then
+			copy_skel "$remote_skel"
+		else
+			copy_skel /etc/skel
+		fi
+
 		# bind mount ~/remote to nfs
 		echo "ocf-mount-remote: bind mounting $remote_source/ to $remote_dest."
 		mkdir -p "$remote_dest"

--- a/modules/managed-deployment.nix
+++ b/modules/managed-deployment.nix
@@ -31,7 +31,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    deployment.allowLocalDeployment = true; #for debugging and deploying when github actions deployment breaks
+    deployment.allowLocalDeployment = true; # for debugging and deploying when github actions deployment breaks
 
     nix.settings.trusted-users = [ deploy-user ];
 


### PR DESCRIPTION
tmpfs homes (which desktops use): copy skel from remote if ~/.config/ocf/skel exists on remote.

needs to be tested