### PR TITLE
add devenv binary cache

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -45,6 +45,10 @@ in
       trusted-substituters = [ "https://devenv.cachix.org" ];
       trusted-public-keys = [ "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=" ];
     };
+    extraOptions = ''
+      extra-substituters = https://devenv.cachix.org
+      extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=
+    '';
   };
 
   nixpkgs.flake.setNixPath = true;


### PR DESCRIPTION
tested on desktop and works, necessary for entering dev shell without waiting forever to build