### PR TITLE
add preliminary ocf.zfs module, enable on desktops

### DIFF
--- a/modules/zfs.nix
+++ b/modules/zfs.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.ocf.zfs;
+in
+{
+  options.ocf.zfs = {
+    enable = lib.mkEnableOption "Enable ZFS support";
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.supportedFilesystems = [ "zfs" ];
+
+    environment.systemPackages = with pkgs; [
+      httm
+
+      # syncoid/findoid are useful regardless of whether sanoid is used
+      sanoid
+    ];
+  };
+}

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -22,6 +22,7 @@
     network.wakeOnLan.enable = true;
     logged-in-users-exporter.enable = true;
 
+    zfs.enable = true;
     nfs = {
       enable = true;
       mount = true;


### PR DESCRIPTION
enable on desktops so that zfs can be mounted from external drives