### PR TITLE
desktops: use linux lts instead of linux zen

### DIFF
--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -43,9 +43,6 @@
     loader.systemd-boot.consoleMode = "max";
     loader.timeout = 0;
     initrd.systemd.enable = true;
-
-    # zen kernel for a more responsive desktop
-    kernelPackages = pkgs.linuxPackages_zen;
   };
 
   # FIXME: suspend causes problems with nfs. disable until we fix this


### PR DESCRIPTION
prioritize stability by using the default linux package in stable nixpkgs (lts) instead of zen.