### PR TITLE
add niks3 push script

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -284,6 +284,9 @@
         ocf-cosmic-applets = ocf-cosmic-applets.packages.${final.stdenv.hostPlatform.system}.default;
         ocf-cosmic-greeter = final.callPackage ./pkgs/ocf-cosmic-greeter.nix { };
         ocf-hplip = final.callPackage ./pkgs/ocf-hplip.nix { };
+        ocf-niks3-push = final.callPackage ./pkgs/ocf-niks3-push {
+          niks3 = niks3.packages.${final.stdenv.hostPlatform.system}.default;
+        };
       };
 
       agenix-rekey = agenix-rekey.configure {

--- a/pkgs/ocf-niks3-push/default.nix
+++ b/pkgs/ocf-niks3-push/default.nix
@@ -1,3 +1,6 @@
+# FIXME: there has to be a better way of doing this,
+#        maybe look into using cellar with oidc when
+#        they add it someday (https://github.com/blitz/celler)
 {
   python3Packages,
   niks3,

--- a/pkgs/ocf-niks3-push/default.nix
+++ b/pkgs/ocf-niks3-push/default.nix
@@ -1,0 +1,26 @@
+{
+  python3Packages,
+  niks3,
+  makeWrapper,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "ocf-niks3-push";
+  version = "0.1.0";
+  format = "other";
+
+  src = ./.;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = with python3Packages; [
+    requests
+    requests-kerberos
+  ];
+
+  installPhase = ''
+    install -Dm755 ocf-niks3-push.py $out/bin/niks3-push
+    wrapProgram $out/bin/niks3-push \
+      --prefix PATH : ${niks3}/bin
+  '';
+}

--- a/pkgs/ocf-niks3-push/ocf-niks3-push.py
+++ b/pkgs/ocf-niks3-push/ocf-niks3-push.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Push Nix store paths to the OCF binary cache via SPNEGO + OIDC."""
+
+import base64
+import hashlib
+import os
+import secrets
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+
+import requests
+from requests_kerberos import OPTIONAL, HTTPKerberosAuth
+
+REALM = "https://idm.ocf.berkeley.edu/realms/ocf/protocol/openid-connect"
+CLIENT_ID = "niks3"
+REDIRECT_URI = "http://127.0.0.1/cb"
+SERVER_URL = "https://cache.ocf.berkeley.edu"
+
+
+def pkce_pair():
+    """Generate a PKCE code verifier and its S256 challenge."""
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def get_token():
+    """Authenticate to Keycloak via SPNEGO and return an OIDC access token."""
+    verifier, challenge = pkce_pair()
+    state = secrets.token_urlsafe(16)
+
+    # SPNEGO auth request — Keycloak sees the Kerberos ticket and redirects
+    # with an authorization code. We intercept the redirect instead of following it.
+    resp = requests.get(
+        f"{REALM}/auth?" + urllib.parse.urlencode({
+            "client_id": CLIENT_ID,
+            "response_type": "code",
+            "redirect_uri": REDIRECT_URI,
+            "scope": "openid groups",
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }),
+        auth=HTTPKerberosAuth(mutual_authentication=OPTIONAL),
+        allow_redirects=False,
+        timeout=15,
+    )
+    if resp.status_code == 401:
+        sys.exit("No valid Kerberos ticket. Run: kinit")
+    if resp.status_code not in (302, 303):
+        sys.exit(f"Unexpected response from Keycloak: {resp.status_code}")
+
+    # Extract the authorization code from the redirect Location header.
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(resp.headers["Location"]).query)
+    if "error" in qs:
+        sys.exit(f"OAuth error: {qs['error'][0]}")
+    assert qs.get("state", [None])[0] == state, "OAuth state mismatch"
+
+    # Exchange the code for an access token.
+    resp = requests.post(f"{REALM}/token", timeout=15, data={
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": qs["code"][0],
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    })
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(f"Usage: {sys.argv[0]} <store-path>...")
+
+    token = get_token()
+
+    # niks3 reads the token from a file, not an env var.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".tok", delete=False) as f:
+        os.chmod(f.name, 0o600)
+        f.write(token)
+
+    try:
+        sys.exit(subprocess.call(
+            ["niks3", "push"] + sys.argv[1:],
+            env={
+                **os.environ,
+                "NIKS3_SERVER_URL": SERVER_URL,
+                "NIKS3_AUTH_TOKEN_FILE": f.name,
+            },
+        ))
+    finally:
+        os.unlink(f.name)
+
+
+if __name__ == "__main__":
+    main()

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -228,6 +228,7 @@ in
       ]
     ))
     ocf-utils
+    ocf-niks3-push
   ];
 
   programs.vim.enable = true;


### PR DESCRIPTION
adds a user script for pushing to niks3 called `niks3-push`. this is basically a wrapper for `niks3` that does ocf auth (OIDC).

only staff are allowed to push using this tool

adds to #318 