### PR TITLE
mitigate Dirty Frag LPE (CVE-pending): blacklist esp4, esp6, rxrpc

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -63,6 +63,14 @@ in
     hostPubkey = lib.mkIf (builtins.pathExists hostKeyFile) (builtins.readFile hostKeyFile);
   };
 
+  # Mitigate Dirty Frag (universal Linux LPE via esp4/esp6/rxrpc page-cache write)
+  # https://github.com/V4bel/dirtyfrag
+  boot.extraModprobeConfig = ''
+    install esp4 /bin/false
+    install esp6 /bin/false
+    install rxrpc /bin/false
+  '';
+
   boot.tmp.useTmpfs = true;
 
   boot.loader = {


### PR DESCRIPTION
Block the esp4, esp6, and rxrpc kernel modules to mitigate the Dirty Frag universal Linux local privilege escalation vulnerability.

https://github.com/V4bel/dirtyfrag

Generated with [Devin](https://cli.devin.ai/docs)