### PR TITLE
base.nix: mount /remote and /services by default

### DIFF
--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -16,11 +16,7 @@ in
 {
   options.ocf.home = {
     tmpfs = lib.mkEnableOption "mount tmpfs on /home and each user's home directory (unmounted on logout)";
-    mountRemote = lib.mkOption {
-      type = lib.types.bool;
-      default = config.ocf.nfs.mount && config.ocf.nfs.asRemote;
-      description = "nfs mount ~/remote, copy skel from remote on login if it exists";
-    };
+    mountRemote = lib.mkEnableOption "nfs mount ~/remote, copy skel from remote on login if it exists";
   };
 
   config = lib.mkIf cfg.tmpfs {

--- a/modules/login-server.nix
+++ b/modules/login-server.nix
@@ -32,6 +32,11 @@ in
         mount = true;
         asRemote = false;
         kerberos = false;
+
+        # if nfs servers are down, the login servers will be so broken that you
+        # might as well freeze all io to the nfs mounts at /home and /services.
+        # this would also be better for data integrity.
+        softerr = false;
       };
 
       programs.mosh.enable = true;

--- a/modules/login-server.nix
+++ b/modules/login-server.nix
@@ -30,6 +30,8 @@ in
       ocf.nfs = {
         enable = true;
         mount = true;
+        asRemote = false;
+        kerberos = false;
       };
 
       programs.mosh.enable = true;

--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -19,13 +19,41 @@ let
     "sync"
     "vers=4.2" # force version 4.2
     "bg" # mount in background and continue booting
-    "timeo=150" # 15s timeout instead of default 60s
-    "retrans=3"
     "nconnect=8" # 8 connections instead of 1
 
     (lib.optional cfg.kerberos "sec=krb5p")
     (lib.optional cfg.cache "fsc")
-    (lib.optional cfg.softerr "softerr")
+
+    # - hard will retry indefinitely.
+    # - softerr will retry retrans number of times with timeo seconds between
+    #   each attempt before returning an io error (per rpc request).
+    # - softerr prioritizes responsiveness, and should rapid fire the retries
+    #   so that a minor hiccup doesnt turn into a minute long freeze. however,
+    #   hard should have a longer timeout so that it doesnt spam the nfs server
+    #   indefinitely for every rpc request. for example, on a desktop system
+    #   where nfs is not critical to everything working, if nfs did not respond
+    #   in 15 seconds, freezing the file browser is more frustrating than it is
+    #   worth.
+    # - hard should be used on hosts where the nfs mount is critical to the
+    #   entire functionality of the system, and it makes sense to just hang write
+    #   requests and flush them when the nfs server is back up. hard is also
+    #   preferable for data integrity.
+    (
+      if cfg.softerr then
+        [
+          # retry 4 times, 2s timeout each
+          "timeo=20"
+          "retrans=4"
+          "softerr"
+        ]
+      else
+        [
+          # retry 3 times, 30s timeout each
+          "timeo=300"
+          "retrans=3"
+          "hard"
+        ]
+    )
   ];
 in
 {
@@ -51,7 +79,7 @@ in
     cache = lib.mkEnableOption "Whether to use cachefilesd and FS-Cache";
     softerr = lib.mkOption {
       type = lib.types.bool;
-      default = true; # otherwise, if nfs cant mount, ssh session will hang
+      default = true;
       description = "Whether to use softerr";
     };
   };

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -66,6 +66,42 @@ in
     cli.enable = lib.mkDefault true;
     motd.enable = lib.mkDefault true;
     etc.enable = true;
+
+    # the case against globally nfs mounted /home:
+    # - you can scp between hosts
+    # - global /home (and global user config as a result) introduces a huge
+    #   dependency on the nfs server for being able to login anywhere (logins
+    #   would hang if nfs was down).
+    # - global /home means that we are trusting every host (and every program
+    #   running as any user on any host) not to write malicious files/config
+    #   on the shared home directory which then instantly propagates to every
+    #   other host at the ocf (catastrophic).
+    #
+    # this is a middle ground that provides convenient access to the global
+    # home directories:
+    # - nfs server is configured with root_squash and only allows acting as a
+    #   user other than nobody if a valid kerberos ticket is available.
+    # - similar to the desktops, global homes are mounted at /remote and
+    #   /services by default on every host.
+    # - unlike desktops, these global homes are not looked at for
+    #   configuration or a bind mount at ~/remote.
+    # - nfs client should not expect a ticket to be available, as the user may
+    #   not have logged with GSSAPI authenticated ssh; thus the nfs client
+    #   should not touch /remote or /services at all without the user manually
+    #   doing so with a ticket.
+    # - softerr is used to prevent infinite hangs on IO operations to /remote
+    #   and /services in the case that the nfs server is down.
+    nfs = {
+      enable = lib.mkDefault true;
+      mount = lib.mkDefault true;
+      kerberos = lib.mkDefault true;
+      softerr = lib.mkDefault true;
+
+      # instead of having an nfs mount for each logged in user, we mount a
+      # single nfs mount at /remote and if ocf.home.mountRemote is true, bind
+      # mount ~/remote -> /remote/w/wa/waddles (for username waddles)
+      asRemote = lib.mkDefault true;
+    };
   };
 
   age.rekey = {

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -19,19 +19,11 @@
     acme.enable = false;
 
     home.tmpfs = true;
+    home.mountRemote = true;
     network.wakeOnLan.enable = true;
     logged-in-users-exporter.enable = true;
 
     zfs.enable = true;
-    nfs = {
-      enable = true;
-      mount = true;
-      kerberos = true;
-
-      # we keep a single nfs mount and then bind mount to it instead of having
-      # many nfs mounts (each logged in user would need a mount)
-      asRemote = true;
-    };
 
     gui.enable = true;
     gui.apps.enable = true;


### PR DESCRIPTION
this is something i have considered but was conflicted on. however, after a discussion with ~jaysa, i am considering a middle ground (see comment in profiles/base.nix).