### PR TITLE
gh actions: use nix-fast-build instead of colmena build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
         # `--evaluator streaming` would be preferable, but it results in
         # colmena exiting as successful after 2 seconds without doing anything,
         # even if nix-eval-jobs is installed.
-        run: nix develop -c nix-fast-build --flake .#colmenaHive.toplevel
+        run: nix develop -c nix-fast-build --no-nom --flake .#colmenaHive.toplevel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
         # `--evaluator streaming` would be preferable, but it results in
         # colmena exiting as successful after 2 seconds without doing anything,
         # even if nix-eval-jobs is installed.
-        run: nix develop -c colmena build --keep-result --nix-option keep-going true -v
+        run: nix develop -c nix-fast-build --flake .#colmenaHive.toplevel

--- a/flake.nix
+++ b/flake.nix
@@ -300,6 +300,7 @@
             pkgs.age-plugin-fido2-hmac
             pkgs.wol
             pkgs.nixfmt-tree
+            pkgs.nix-fast-build
             colmena.packages.${pkgs.stdenv.hostPlatform.system}.colmena
           ];
         };
@@ -309,6 +310,7 @@
             pkgs.openssh
             pkgs.wol
             pkgs.nixfmt-tree
+            pkgs.nix-fast-build
             colmena.packages.${pkgs.stdenv.hostPlatform.system}.colmena
           ];
         };


### PR DESCRIPTION
`colmena build --evaluator streaming` does not work and instead returns success after 5 seconds of doing seemingly nothing. so lets use nix-fast-build instead. this only affects build, not deploy.