### PR TITLE
require cups config service to start with cups

### DIFF
--- a/modules/printhost/cups.nix
+++ b/modules/printhost/cups.nix
@@ -112,13 +112,12 @@ in
       '';
     };
 
-    # Declaratively configure all printers and classes on every boot.
+    # Declaratively configure all printers and classes on cups service start.
     # Runs after cups.service since /var/lib/cups is stateless.
     systemd.services.cups-setup-printers = {
       description = "Declaratively configure CUPS printers and classes";
       after = [ "cups.service" ];
-      wants = [ "cups.service" ];
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = [ "cups.service" ];
       partOf = [ "cups.service" ];
       path = [ config.services.printing.package ];
       serviceConfig.Type = "oneshot";


### PR DESCRIPTION
currently starts at boot, which breaks if cups crashes or is restarted due to another service (ex: acme cert renewal)