### PR TITLE
simplify nix.conf options

### DIFF
--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -41,9 +41,8 @@ in
       dates = "weekly";
     };
     settings = {
-      # makes devenv shells build significantly faster
-      trusted-substituters = [
-        "https://devenv.cachix.org"
+      substituters = [
+        "https://devenv.cachix.org" # makes devenv shells build significantly faster
         "https://cache.ocf.berkeley.edu"
       ];
       trusted-public-keys = [
@@ -51,10 +50,6 @@ in
         "cache.ocf.berkeley.edu-1:6n9lihkjExzagz8GYR1QY/ZthT/XAKOy+ju5Jxd6wBg="
       ];
     };
-    extraOptions = ''
-      extra-substituters = https://devenv.cachix.org https://cache.ocf.berkeley.edu
-      extra-trusted-public-keys = devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw= cache.ocf.berkeley.edu-1:6n9lihkjExzagz8GYR1QY/ZthT/XAKOy+ju5Jxd6wBg=
-    '';
   };
 
   nixpkgs.flake.setNixPath = true;


### PR DESCRIPTION
using `nix.settings.substituters` will add the cache to the list of automatic substituters without the need for the additional `extra-substituters` config which is required when just adding the cache as a trusted substituter

https://search.nixos.org/options?channel=25.11&query=nix.settings.substituters
https://search.nixos.org/options?channel=25.11&query=nix.settings.trusted-substituters