### PR TITLE
update kubernetes to 1.36.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -395,6 +395,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "ocf-cosmic-applets": {
       "inputs": {
         "crane": "crane",
@@ -596,6 +612,7 @@
         "niks3": "niks3",
         "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "ocf-cosmic-applets": "ocf-cosmic-applets",
         "ocf-jukebox": "ocf-jukebox",
         "ocf-pam-trimspaces": "ocf-pam-trimspaces",

--- a/flake.nix
+++ b/flake.nix
@@ -254,14 +254,16 @@
           meta = {
             nixpkgs = pkgsFor defaultSystem;
             nodeNixpkgs = nixpkgs.lib.mapAttrs (name: pkgsFor) overrideSystem;
-            specialArgs = { 
+            specialArgs = {
               inherit self inputs;
               # pkgs-unstable exposes the packages from the nixpkgs-unstable input
               # this should only be used as a *temporary* measure when the version of
               # a package in nixpkgs stable is not sufficiently updated
               pkgs-unstable = pkgsUnstableFor defaultSystem;
             };
-            nodeSpecialArgs = nixpkgs.lib.mapAttrs (name: value: { pkgs-unstable = pkgsUnstableFor value; }) overrideSystem;
+            nodeSpecialArgs = nixpkgs.lib.mapAttrs (name: value: {
+              pkgs-unstable = pkgsUnstableFor value;
+            }) overrideSystem;
           };
         }
       );
@@ -380,14 +382,14 @@
 
       nixosConfigurations = builtins.mapAttrs (
         host: colmenaConfig:
-        let 
+        let
           system = overrideSystem.${host} or defaultSystem;
         in
         nixpkgs.lib.nixosSystem {
           inherit system;
           pkgs = pkgsFor system;
           modules = colmenaConfig.imports;
-          specialArgs = { 
+          specialArgs = {
             inherit inputs;
             pkgs-unstable = pkgsUnstableFor system;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,9 @@
             nodeNixpkgs = nixpkgs.lib.mapAttrs (name: pkgsFor) overrideSystem;
             specialArgs = { 
               inherit self inputs;
+              # pkgs-unstable exposes the packages from the nixpkgs-unstable input
+              # this should only be used as a *temporary* measure when the version of
+              # a package in nixpkgs stable is not sufficiently updated
               pkgs-unstable = pkgsUnstableFor defaultSystem;
             };
             nodeSpecialArgs = nixpkgs.lib.mapAttrs (name: value: { pkgs-unstable = pkgsUnstableFor value; }) overrideSystem;

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,13 @@
       ref = "nixos-25.11";
     };
 
+    nixpkgs-unstable = {
+      type = "github";
+      owner = "nixos";
+      repo = "nixpkgs";
+      ref = "nixos-unstable";
+    };
+
     systems = {
       type = "github";
       owner = "nix-systems";
@@ -120,6 +127,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-unstable,
       systems,
       colmena,
       agenix,
@@ -200,6 +208,12 @@
           };
         };
 
+      pkgsUnstableFor =
+        system:
+        import nixpkgs-unstable {
+          inherit system;
+        };
+
       forAllSystems = fn: nixpkgs.lib.genAttrs (import systems) (system: fn (pkgsFor system));
 
       readGroup =
@@ -240,7 +254,11 @@
           meta = {
             nixpkgs = pkgsFor defaultSystem;
             nodeNixpkgs = nixpkgs.lib.mapAttrs (name: pkgsFor) overrideSystem;
-            specialArgs = { inherit self inputs; };
+            specialArgs = { 
+              inherit self inputs;
+              pkgs-unstable = pkgsUnstableFor defaultSystem;
+            };
+            nodeSpecialArgs = nixpkgs.lib.mapAttrs (name: value: { pkgs-unstable = pkgsUnstableFor value; }) overrideSystem;
           };
         }
       );
@@ -359,11 +377,17 @@
 
       nixosConfigurations = builtins.mapAttrs (
         host: colmenaConfig:
-        nixpkgs.lib.nixosSystem rec {
+        let 
           system = overrideSystem.${host} or defaultSystem;
+        in
+        nixpkgs.lib.nixosSystem {
+          inherit system;
           pkgs = pkgsFor system;
           modules = colmenaConfig.imports;
-          specialArgs = { inherit inputs; };
+          specialArgs = { 
+            inherit inputs;
+            pkgs-unstable = pkgsUnstableFor system;
+          };
         }
       ) colmenaHosts;
     };

--- a/modules/kubernetes/default.nix
+++ b/modules/kubernetes/default.nix
@@ -7,13 +7,13 @@
 
 let
   kubernetes = pkgs.kubernetes.overrideAttrs (oldAttrs: rec {
-    version = "1.33.3";
+    version = "1.36.1";
     src = pkgs.fetchFromGitHub {
       owner = "kubernetes";
       repo = "kubernetes";
       rev = "v${version}";
       # make sure to update hash if changing kubernetes version
-      hash = "sha256-UZdrfQEEx0RRe4Bb4EAWcjgCCLq4CJL06HIriYuk1Io=";
+      hash = "sha256-QG2zFaFtGXoWIlyp3hVBRU+OHre/6vWcvijUe1DdjIo=";
     };
   });
   kubePkgs = with pkgs; [

--- a/modules/kubernetes/default.nix
+++ b/modules/kubernetes/default.nix
@@ -1,12 +1,15 @@
 {
   config,
   pkgs,
+  pkgs-unstable,
   lib,
   ...
 }:
 
 let
-  kubernetes = pkgs.kubernetes.overrideAttrs (oldAttrs: rec {
+  # TODO kubernetes 1.36 requires go > 1.26. revert to stable nixpkgs
+  # once go version is > 1.26
+  kubernetes = pkgs-unstable.kubernetes.overrideAttrs (oldAttrs: rec {
     version = "1.36.1";
     src = pkgs.fetchFromGitHub {
       owner = "kubernetes";


### PR DESCRIPTION
updates kubernetes version to 1.36.1

additionally adds nixpkgs-unstable as a flake input and exposes it to modules as pkgs-unstable
this is due to kubernetes >= 1.36 requiring go >= 1.26, meaning kubernetes needs to be built from nixpkgs-unstable until stable nixpkgs has go version >= 1.26