### PR TITLE
gh actions: add support for merge queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build Hosts
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
 
 concurrency:
   group: build-${{ github.ref || github.head_ref }}


### PR DESCRIPTION
currently, when there are multiple pull requests to main, we have to merge them sequentially: updating the next branch after the previous branch has been merged. merge queues do this process automatically.