### PR TITLE
gui: setup ssh agent and askpass on login

### DIFF
--- a/modules/gui/default.nix
+++ b/modules/gui/default.nix
@@ -112,8 +112,16 @@ in
         "xdg/kitty/no-preference-theme.auto.conf".source = "${kittyThemes}/rose-pine.conf";
       };
 
-    # Conflict override since multiple DEs set this option
-    programs.ssh.askPassword = pkgs.lib.mkForce (lib.getExe pkgs.ksshaskpass.out);
+    programs.ssh = {
+      # setup ssh agent with askpass on login by default
+      # if you want to forward a fido ssh key that requires a pin, the ssh agent
+      # needs askpass to prompt for the pin when the agent uses the key.
+      startAgent = true;
+      enableAskPassword = true;
+
+      # Conflict override since multiple DEs set this option
+      askPassword = pkgs.lib.mkForce (lib.getExe pkgs.kdePackages.ksshaskpass);
+    };
 
     xdg.portal = {
       enable = true;


### PR DESCRIPTION
specifically, this adds support for using a fido ssh key that requires a pin on a remote ssh server via agent forwarding.