### PR TITLE
add kobudai interfaces to bond

### DIFF
--- a/hosts/server/kobudai.nix
+++ b/hosts/server/kobudai.nix
@@ -1,7 +1,13 @@
 {
   ocf.network = {
     enable = true;
-    bond.enable = true;
+    bond = {
+      enable = true;
+      interfaces = [
+        "eno1"
+        "eno2"
+      ];
+    };
     lastOctet = 6;
   };
 


### PR DESCRIPTION
adds the network interfaces on kobudai to the bond network explicitly

this has been tested and works properly (and is currently deployed on kobudai)

currently a deploy from main will break kobudai until this fix is merged