### PR TITLE
only set serial console as primary on vms

### DIFF
--- a/hardware/virtualized.nix
+++ b/hardware/virtualized.nix
@@ -11,6 +11,11 @@
     (modulesPath + "/profiles/qemu-guest.nix")
   ];
 
+  # enable vga and serial consoles, with serial as primary
+  # see: https://docs.kernel.org/admin-guide/serial-console.html
+  # "last device will be used when you open /dev/console"
+  boot.kernelParams = [ "console=tty0" "console=ttyS0,115200" ];
+
   boot.initrd.availableKernelModules = [
     "ahci"
     "xhci_pci"

--- a/hardware/virtualized.nix
+++ b/hardware/virtualized.nix
@@ -14,7 +14,10 @@
   # enable vga and serial consoles, with serial as primary
   # see: https://docs.kernel.org/admin-guide/serial-console.html
   # "last device will be used when you open /dev/console"
-  boot.kernelParams = [ "console=tty0" "console=ttyS0,115200" ];
+  boot.kernelParams = [
+    "console=tty0"
+    "console=ttyS0,115200"
+  ];
 
   boot.initrd.availableKernelModules = [
     "ahci"

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -91,8 +91,6 @@ in
     hostPubkey = lib.mkIf (builtins.pathExists hostKeyFile) (builtins.readFile hostKeyFile);
   };
 
-  boot.kernelParams = [ "console=ttyS0,115200" ];
-
   # Mitigate Dirty Frag (universal Linux LPE via esp4/esp6/rxrpc page-cache write)
   # https://github.com/V4bel/dirtyfrag
   boot.extraModprobeConfig = ''


### PR DESCRIPTION
previously i advised rosie in #374 to just set serial console in base.nix for everything because i incorrectly assumed that linux will still display to tty0 and only add ttyS0 as a console. that was dumb in hindsight and thats my bad because of course thats not how it works...

in the future, maybe it would be useful to have a nixos module that automatically enables serial kernel console if it is present, but use vga tty0 as the primary. then we can have an option to set serial as primary on hosts as needed.