### PR TITLE
fix descriptions for mkEnableOption

### DIFF
--- a/modules/acme.nix
+++ b/modules/acme.nix
@@ -11,13 +11,9 @@ in
 {
   options.ocf.acme = {
 
-    enable = lib.mkEnableOption "Enable OCF ACME";
+    enable = lib.mkEnableOption "OCF ACME";
 
-    shortlived = lib.mkOption {
-      type = lib.types.bool;
-      description = "Enable Using Short Lived (6 Day) Certs";
-      default = false;
-    };
+    shortlived = lib.mkEnableOption "using Short Lived (6 Day) Certs";
 
     extraCerts = lib.mkOption {
       type = lib.types.listOf lib.types.str;

--- a/modules/auth.nix
+++ b/modules/auth.nix
@@ -39,7 +39,7 @@ let
 in
 {
   options.ocf.auth = {
-    enable = lib.mkEnableOption "Enable OCF authentication";
+    enable = lib.mkEnableOption "OCF authentication";
     staffOnlySSH = lib.mkOption {
       type = lib.types.bool;
       description = "Restrict SSH access to ocfstaff and ocfroot. Disable for public login servers (as of now, only carp).";

--- a/modules/cli/apps.nix
+++ b/modules/cli/apps.nix
@@ -9,7 +9,7 @@ let
   cfg = config.ocf.cli.apps;
 in
 {
-  options.ocf.cli.apps.enable = lib.mkEnableOption "Install CLI apps";
+  options.ocf.cli.apps.enable = lib.mkEnableOption "CLI apps";
 
   config = lib.mkIf cfg.enable {
     programs.java.enable = true; # set $JAVA_HOME

--- a/modules/cli/default.nix
+++ b/modules/cli/default.nix
@@ -10,7 +10,7 @@ let
 in
 {
   options.ocf.cli = {
-    enable = lib.mkEnableOption "Enable shell configuration";
+    enable = lib.mkEnableOption "shell configuration";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/etc.nix
+++ b/modules/etc.nix
@@ -10,7 +10,7 @@ let
 in
 {
   options.ocf.etc = {
-    enable = lib.mkEnableOption "Enable /etc/ocf configuration";
+    enable = lib.mkEnableOption "syncing /etc/ocf config files";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/github-actions/options.nix
+++ b/modules/github-actions/options.nix
@@ -2,7 +2,7 @@
 
 {
   options.ocf.github-actions = {
-    enable = lib.mkEnableOption "Enable Containerized OCF GitHub Actions Runners";
+    enable = lib.mkEnableOption "Containerized OCF GitHub Actions Runners";
     runners = lib.mkOption {
       type = lib.types.listOf (
         lib.types.submodule (
@@ -10,7 +10,7 @@
           {
 
             options = {
-              enable = lib.mkEnableOption "Enable this self-hosted runner";
+              enable = lib.mkEnableOption "this self-hosted runner";
 
               owner = lib.mkOption {
                 type = lib.types.str;

--- a/modules/gui/apps/apps.nix
+++ b/modules/gui/apps/apps.nix
@@ -9,7 +9,7 @@ let
   cfg = config.ocf.gui.apps;
 in
 {
-  options.ocf.gui.apps.enable = lib.mkEnableOption "Enable development related apps";
+  options.ocf.gui.apps.enable = lib.mkEnableOption "development related apps";
 
   config = lib.mkIf cfg.enable {
     hardware.graphics.enable32Bit = true;

--- a/modules/gui/default.nix
+++ b/modules/gui/default.nix
@@ -48,7 +48,7 @@ let
 in
 {
   options.ocf.gui = {
-    enable = lib.mkEnableOption "Enable desktop environment configuration";
+    enable = lib.mkEnableOption "desktop environment configuration";
 
     # FIXME: this doesnt check if the given value is a valid session
     desktop = lib.mkOption {

--- a/modules/gui/kiosk.nix
+++ b/modules/gui/kiosk.nix
@@ -17,7 +17,7 @@ let
 in
 {
   options.ocf.gui.kiosk = {
-    enable = lib.mkEnableOption "Enable Kiosk configuration";
+    enable = lib.mkEnableOption "Kiosk configuration";
     url = lib.mkOption {
       type = lib.types.str;
       description = "URL to open the Kiosk with";

--- a/modules/home/home.nix
+++ b/modules/home/home.nix
@@ -15,7 +15,7 @@ let
 in
 {
   options.ocf.home = {
-    tmpfs = lib.mkEnableOption "mount tmpfs on /home and each user's home directory (unmounted on logout)";
+    tmpfs = lib.mkEnableOption "tmpfs mount on /home and each user's home directory (unmounted on logout)";
     mountRemote = lib.mkEnableOption "nfs mount ~/remote, copy skel from remote on login if it exists";
   };
 

--- a/modules/irc.nix
+++ b/modules/irc.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options.ocf.irc = {
-    enable = lib.mkEnableOption "Enable IRC Server";
+    enable = lib.mkEnableOption "OCF IRC Server";
     motd = lib.mkOption {
       type = lib.types.str;
       description = "Message of the Day";

--- a/modules/kubernetes/default.nix
+++ b/modules/kubernetes/default.nix
@@ -39,13 +39,8 @@ in
 {
   # Configuration for Nodes
   options.services.ocfKubernetes = {
-    enable = lib.mkEnableOption "Enables everything needed to run kubeadm.";
-    isLeader = lib.mkOption {
-      default = false;
-      example = true;
-      description = "Currently identical to worker, but enables kube-vip as a static pod.";
-      type = lib.types.bool;
-    };
+    enable = lib.mkEnableOption "everything needed to run kubeadm";
+    isLeader = lib.mkEnableOption "kube-vip as a static pod";
   };
 
   config = lib.mkIf config.services.ocfKubernetes.enable {

--- a/modules/logged-in-users-exporter/default.nix
+++ b/modules/logged-in-users-exporter/default.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options.ocf.logged-in-users-exporter = {
-    enable = mkEnableOption "Enable logged in users exporter for Prometheus (used by OCF Labmap)";
+    enable = mkEnableOption "logged in users exporter for Prometheus (used by OCF Labmap)";
     interval = mkOption {
       type = types.int;
       default = 5;

--- a/modules/managed-deployment.nix
+++ b/modules/managed-deployment.nix
@@ -30,7 +30,7 @@ let
   ];
 in
 {
-  options.ocf.managed-deployment.enable = lib.mkEnableOption "Enable OCF Colmena / GitHub Actions Managed Deployment";
+  options.ocf.managed-deployment.enable = lib.mkEnableOption "OCF Colmena / GitHub Actions Managed Deployment";
 
   options.ocf.managed-deployment.automated-deploy = lib.mkOption {
     type = lib.types.bool;

--- a/modules/matrix/default.nix
+++ b/modules/matrix/default.nix
@@ -14,7 +14,7 @@ let
 in
 {
   options.ocf.matrix = {
-    enable = lib.mkEnableOption "Enable Matrix server";
+    enable = lib.mkEnableOption "Matrix server";
 
     postgresPackage = lib.mkOption {
       type = lib.types.package;

--- a/modules/matrix/discord-bridge.nix
+++ b/modules/matrix/discord-bridge.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options.ocf.matrix.discord-bridge = {
-    enable = lib.mkEnableOption "Enable Matrix Discord bridge.";
+    enable = lib.mkEnableOption "Matrix Discord bridge";
   };
 
   config = lib.mkIf cfg.discord-bridge.enable {

--- a/modules/matrix/element.nix
+++ b/modules/matrix/element.nix
@@ -10,11 +10,11 @@ let
 in
 {
   options.ocf.matrix.element = {
-    enable = lib.mkEnableOption "Enable Element web client.";
+    enable = lib.mkEnableOption "Element web client";
 
     url = lib.mkOption {
       type = lib.types.str;
-      description = "Element URL.";
+      description = "Element URL";
     };
   };
 

--- a/modules/matrix/irc-bridge.nix
+++ b/modules/matrix/irc-bridge.nix
@@ -10,7 +10,7 @@ let
 in
 {
   options.ocf.matrix.irc-bridge = {
-    enable = lib.mkEnableOption "Enable Matrix IRC bridge.";
+    enable = lib.mkEnableOption "Matrix IRC bridge";
 
     server = lib.mkOption {
       type = lib.types.str;

--- a/modules/motd.nix
+++ b/modules/motd.nix
@@ -23,7 +23,7 @@ let
 in
 {
   options.ocf.motd = {
-    enable = lib.mkEnableOption "Enable OCF MOTD";
+    enable = lib.mkEnableOption "OCF MOTD";
 
     description = lib.mkOption {
       type = lib.types.str;

--- a/modules/network/bond.nix
+++ b/modules/network/bond.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.ocf.network.bond = {
-    enable = lib.mkEnableOption "Enable bonding network interfaces";
+    enable = lib.mkEnableOption "bonding network interfaces";
     interfaces = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       description = "Name of the network interfaces to bond";

--- a/modules/network/default.nix
+++ b/modules/network/default.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.ocf.network = {
-    enable = lib.mkEnableOption "Enable OCF network configuration";
+    enable = lib.mkEnableOption "OCF network configuration";
     interface = lib.mkOption {
       type = lib.types.str;
       description = "Name of the network interface to configure";
@@ -21,7 +21,7 @@ in
       default = [ ];
     };
 
-    wakeOnLan.enable = lib.mkEnableOption "Enable Wake-on-LAN";
+    wakeOnLan.enable = lib.mkEnableOption "Wake-on-LAN";
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -58,7 +58,7 @@ let
 in
 {
   options.ocf.nfs = {
-    enable = lib.mkEnableOption "Enable NFS Mounts (NFS client)";
+    enable = lib.mkEnableOption "NFS Mounts (NFS client)";
 
     # /services is necessary for remote homes since ~/public_html is a symlink
     # to /services
@@ -75,8 +75,8 @@ in
       default = false;
     };
 
-    kerberos = lib.mkEnableOption "Whether to use Kerberos krb5p";
-    cache = lib.mkEnableOption "Whether to use cachefilesd and FS-Cache";
+    kerberos = lib.mkEnableOption "krb5p";
+    cache = lib.mkEnableOption "cachefilesd and FS-Cache";
     softerr = lib.mkOption {
       type = lib.types.bool;
       default = true;

--- a/modules/niks3-push.nix
+++ b/modules/niks3-push.nix
@@ -9,7 +9,7 @@ let
 in
 {
   options.ocf.niks3-push = {
-    enable = lib.mkEnableOption "Auto-push built paths to the OCF binary cache";
+    enable = lib.mkEnableOption "auto-pushing of built paths to the OCF binary cache";
 
     cacheDomain = lib.mkOption {
       type = lib.types.str;

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -5,7 +5,7 @@ let
 in
 {
   options.ocf.nvidia = {
-    enable = lib.mkEnableOption "Enable NVIDIA Drivers and Config";
+    enable = lib.mkEnableOption "NVIDIA Drivers and Config";
     # See: https://github.com/NVIDIA/open-gpu-kernel-modules#compatible-gpus
     # It's recommend to use the open kernel drivers for turing and above
     open = lib.mkOption {

--- a/modules/webhost.nix
+++ b/modules/webhost.nix
@@ -67,13 +67,13 @@ let
 in
 {
   options.ocf.webhost = {
-    enable = lib.mkEnableOption "Enable static webhosting configuration";
+    enable = lib.mkEnableOption "static webhosting configuration";
     websites = lib.mkOption {
       type = lib.types.listOf (
         lib.types.submodule {
 
           options = {
-            enable = lib.mkEnableOption "Enable this website";
+            enable = lib.mkEnableOption "this website";
 
             name = lib.mkOption {
               type = lib.types.str;

--- a/modules/zfs.nix
+++ b/modules/zfs.nix
@@ -10,7 +10,7 @@ let
 in
 {
   options.ocf.zfs = {
-    enable = lib.mkEnableOption "Enable ZFS support";
+    enable = lib.mkEnableOption "ZFS";
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
according to documentation, mkEnableOption already wraps the given string with
"Whether to enable <name>.”
this commit rewords the descriptions to correctly account for that.

see https://nixos.org/manual/nixos/stable/#sec-option-declarations-util-mkEnableOption

also i ran the excellent `:lvimgrep /mkEnableOpt/g **` at the root of the git
repository, and ran `:w` and `:lnext` after rewording to go to the next match :)
