### PR TITLE
move k8s tooling to modules/cli/apps.nix

### DIFF
--- a/modules/cli/apps.nix
+++ b/modules/cli/apps.nix
@@ -210,8 +210,10 @@ in
       img2pdf
 
       # kubernetes
+      kubectl
       k9s
       argocd
+      teleport.client
 
       # networking
       pssh

--- a/profiles/base.nix
+++ b/profiles/base.nix
@@ -237,11 +237,6 @@ in
 
     comma-with-db
 
-    # k8s
-    teleport
-    k9s
-    kubectl
-
     # OCF utilities
     (config.ocf.python.package.withPackages (
       ps: with ps; [


### PR DESCRIPTION
k8s tooling is not needed on every host. teleport alone removes an
entire gigabite. for example, just removing teleport, k9s, and kubectl
removes a total of 1.21gb from zecora. k8s tooling can be added to a nix
develop shell similar to how colmena is only available in the nix
develop shell for ocf/nix.
