### PR TITLE
nfs: use x-systemd.automount

### DIFF
--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -18,8 +18,19 @@ let
 
     "sync"
     "vers=4.2" # force version 4.2
-    "bg" # mount in background and continue booting
     "nconnect=8" # 8 connections instead of 1
+
+    # - we dont want boot to hang when nfs is down, since this makes debugging
+    #   the machine difficult.
+    # - instead, this mounts it on initial access
+    # - one advantage x-systemd.automount has over the bg option is that
+    #   automount prevent race conditions during boot by freezing io on the
+    #   mountpoint until it is mounted
+    # - fail fast when the nfs server is down at mount time
+    # - there should be no risk of data corruption, since this is on the initial
+    #   open(), not when the file is open and being written to
+    "x-systemd.automount"
+    "x-systemd.mount-timeout=10s"
 
     (lib.optional cfg.kerberos "sec=krb5p")
     (lib.optional cfg.cache "fsc")

--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -32,6 +32,8 @@ let
     "x-systemd.automount"
     "x-systemd.mount-timeout=10s"
 
+    (lib.optional (cfg.idleTimeout != null) "x-systemd.idle-timeout=${toString cfg.idleTimeout}")
+
     (lib.optional cfg.kerberos "sec=krb5p")
     (lib.optional cfg.cache "fsc")
 
@@ -84,6 +86,26 @@ in
       type = lib.types.bool;
       description = "Mount NFS homes to /remote instead of /home (for desktops which create home directory in tmpfs on login).";
       default = false;
+    };
+
+    idleTimeout = lib.mkOption {
+      type = with lib.types; nullOr (either ints.unsigned str);
+      description = ''
+        How long to wait until unmounting an idle nfs mount.
+
+        Accepts a systemd time span value.
+        Set to null to omit the option and use systemd defaults.
+        Set to 0 to disable idle timeout.
+        See TimeoutIdleSec= in systemd.automount(5) for details.
+
+        This can free up resources and prevents slowdowns/freezes on `ls` of the
+        parent directory that the nfs mountpoint is in. Note that this flushes
+        page and metadata caches, which can harm performance on systems that
+        heavily use the nfs mounts and benefit from a warmed cache at all times.
+      '';
+      # many systems that dont use nfs for /home dont need it to be mounted at
+      # all times with a warm cache.
+      default = if cfg.asRemote then "10m" else 0;
     };
 
     kerberos = lib.mkEnableOption "Whether to use Kerberos krb5p";

--- a/modules/nfs.nix
+++ b/modules/nfs.nix
@@ -32,6 +32,8 @@ let
     "x-systemd.automount"
     "x-systemd.mount-timeout=10s"
 
+    (lib.optional (cfg.idleTimeout != null) "x-systemd.idle-timeout=${toString cfg.idleTimeout}")
+
     (lib.optional cfg.kerberos "sec=krb5p")
     (lib.optional cfg.cache "fsc")
 
@@ -88,6 +90,27 @@ in
 
     kerberos = lib.mkEnableOption "krb5p";
     cache = lib.mkEnableOption "cachefilesd and FS-Cache";
+
+    idleTimeout = lib.mkOption {
+      type = with lib.types; nullOr (either ints.unsigned str);
+      description = ''
+        How long to wait until unmounting an idle nfs mount.
+
+        Accepts a systemd time span value.
+        Set to null to omit the option and use systemd defaults.
+        Set to 0 to disable idle timeout.
+        See TimeoutIdleSec= in systemd.automount(5) for details.
+
+        This can free up resources and prevents slowdowns/freezes on `ls` of the
+        parent directory that the nfs mountpoint is in. Note that this flushes
+        page and metadata caches, which can harm performance on systems that
+        heavily use the nfs mounts and benefit from a warmed cache at all times.
+      '';
+      # many systems that dont use nfs for /home dont need it to be mounted at
+      # all times with a warm cache.
+      default = if cfg.asRemote then "10m" else 0;
+    };
+
     softerr = lib.mkOption {
       type = lib.types.bool;
       default = true;

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -24,6 +24,10 @@
     gui.apps.enable = true;
 
     cli.apps.enable = true;
+
+    # desktops heavily use /remote and bind mount to ~/remote on login
+    # keep the mount cached and ready to use at all times
+    nfs.idleTimeout = 0;
   };
 
   boot = {


### PR DESCRIPTION
- **nfs: replace bg with x-systemd.automount**
  

- **nfs: unmount when idle except on login servers and desktops**
  - most systems dont need to maintain an open connection with filehost at all
    times.
  - exception is servers using nfs for /home (login servers) and desktops, both of
    which are the main users of nfs.
  