### PR TITLE
github-actions: fix and enable auto deploy on ci hosts

### DIFF
--- a/modules/github-actions/default.nix
+++ b/modules/github-actions/default.nix
@@ -59,6 +59,23 @@ let
                 };
               }) runner-cfg.instances
             );
+
+            systemd.services = lib.mapAttrs' (runnerName: runnerCfg: {
+              # systemd service is prefixed with "github-runner-"
+              name = "github-runner-${runnerName}";
+
+              # dont interrupt a running job on a nixos configuration switch.
+              # if github-runners.*.ephemeral = true, the runner will exit on
+              # job completion, and systemd will start the updated github
+              # runner.
+              #
+              # NOTE: this means that the runner will only update after the
+              # next job, even if no job was running during the switch
+              value = {
+                restartIfChanged = false;
+              };
+            }) config.services.github-runners;
+
             system.stateVersion = "24.11";
           };
       };
@@ -68,10 +85,17 @@ in
 {
   imports = [ ./options.nix ];
   config = lib.mkIf cfg.enable {
-    # add exemption: automated deployments may cause failures if deploying to themself
-    ocf.managed-deployment.automated-deploy = false;
-
     age.secrets = lib.mkMerge (builtins.map getSecrets cfg.runners);
     containers = lib.mkMerge (builtins.map makeContainer cfg.runners);
+
+    # dont fail/interrupt jobs on a nixos configuration switch by restarting
+    # the container. instead, live reload the containers, which runs
+    # switch-to-configuration within the container.
+    systemd.services = lib.mapAttrs' (containerName: containerCfg: {
+      name = "container@${containerName}";
+      value = {
+        reloadIfChanged = true;
+      };
+    }) config.containers;
   };
 }


### PR DESCRIPTION
bug:
running a nixos configuration switch restarts nixos containers by default. this
means that when the github actions runner runs colmena apply on the ci host, it
would accidentally kill itself, causing the job to fail abruptly.

the bug was fixed with the following changes to switch behavior on ci hosts:
- live reload (switch) nixos containers instead of restarting
- dont restart github runners within the container, let them restart after
  completing a job (due to ephemeral = true)

alternatives:
- restart the github runner with a long timeout:
	- KillSignal is already set to SIGINT by services.github-runners, the runner
	  will wait for the current job to complete before exiting.
	- this means that although it will be updated, the completion of a deploy
	  job will now depend on the completion of all currently running jobs across
	  all runners, *in addition to the deploy job thats deploying to itself*.
	- the latter can be fixed by setting restartIfChanged to false only for the
	  runner executing colmena deploys.
- add an activation script that only restart runners with no running jobs:
	- should be immediate; no need to wait for github runner jobs to complete.
	- let the busy runners restart after they are done with the job.
	- do we report a successful nixos configuration switch even though those
	  runners were not technically restarted yet? they may fail to start after
	  their job completes.
	- more complicated
