### PR TITLE
kubernetes: use nfs v4.2 on nodes

### DIFF
--- a/modules/kubernetes/default.nix
+++ b/modules/kubernetes/default.nix
@@ -52,6 +52,10 @@ in
         source = ./kubevip.yaml;
       };
       "kubernetes/kubeadm.yaml".source = ./kubeadm.yaml;
+      "nfsmount.conf".text = ''
+        [ NFSMount_Global_Options ]
+        vers=4.2
+      '';
     };
 
     # From an OCF alumni, some of these might be unnecessary.


### PR DESCRIPTION
fixes pods that use nfs (create)
this issue was introduced during the nfs nix migration where we disabled use of nfs v3

confirmed working with the create pod after manually placing the file on guanine