### PR TITLE
fix password-less sudo for ocfbackups

### DIFF
--- a/modules/auth.nix
+++ b/modules/auth.nix
@@ -124,7 +124,7 @@ in
           users = [ "ocfbackups" ];
           commands = [
             {
-              command = lib.getExe pkgs.rsync;
+              command = "/run/current-system/sw/bin/ionice";
               options = [ "NOPASSWD" ];
             }
           ];


### PR DESCRIPTION
Note that this is not an actual restriction of the commands ocfbackups can run: e.g. `sudo ionice bash`