### PR TITLE
add ocf.oci for oci tooling

### DIFF
--- a/modules/cli/apps.nix
+++ b/modules/cli/apps.nix
@@ -15,6 +15,8 @@ in
     programs.java.enable = true; # set $JAVA_HOME
     programs.java.package = pkgs.zulu25;
 
+    ocf.oci.enable = true;
+
     environment.systemPackages = with pkgs; [
       # tui editors
       neovim

--- a/modules/oci.nix
+++ b/modules/oci.nix
@@ -26,7 +26,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    hardware.nvidia-container-toolkit.enable = cfg.nvidia;
+    hardware.nvidia-container-toolkit = {
+      enable = cfg.nvidia;
+
+      # prevent build-vm from failing
+      suppressNvidiaDriverAssertion = true;
+    };
 
     virtualisation.podman = {
       enable = true;

--- a/modules/oci.nix
+++ b/modules/oci.nix
@@ -1,0 +1,47 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  cfg = config.ocf.oci;
+in
+{
+  options.ocf.oci = {
+    enable = lib.mkEnableOption "OCI tooling (podman, skopeo, etc)";
+
+    desktop = lib.mkOption {
+      type = lib.types.bool;
+      default = config.ocf.gui.enable;
+      description = "Whether to enable podman-desktop";
+    };
+
+    nvidia = lib.mkOption {
+      type = lib.types.bool;
+      default = config.ocf.nvidia.enable;
+      description = "Whether to enable nvidia-container-toolkit";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.nvidia-container-toolkit.enable = cfg.nvidia;
+
+    virtualisation.podman = {
+      enable = true;
+      autoPrune.enable = true;
+      dockerCompat = true;
+    };
+
+    environment.systemPackages =
+      with pkgs;
+      [
+        skopeo
+        buildah
+        podman-compose
+        podman-tui
+      ]
+      ++ lib.optional cfg.desktop pkgs.podman-desktop;
+  };
+}

--- a/profiles/desktop.nix
+++ b/profiles/desktop.nix
@@ -92,8 +92,6 @@
   # needed for accessing totp codes on yubikey via yubico authenticator
   services.pcscd.enable = true;
 
-  virtualisation.podman.enable = true;
-
   # kill user processes on logout
   # if this is not set to true, the system user manager, processes, home tmpfs
   # mount, etc will linger, causing the logind session and scope to be stuck in


### PR DESCRIPTION
it is strange that desktops get podman-desktop because ocf.cli.apps.enable enables ocf.oci.enable, which adds podman-desktop if ocf.gui.apps.enable is true. my thinking was that ocf.cli.apps enables a lot of development tools for login servers, build servers, and desktops, which should include podman, so that would be the best place to put it and it works fine enough.